### PR TITLE
Enable Link-Time Optimization (LTO)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,5 @@
 [workspace]
 members = ["safeshell", "xtask"]
+
+[profile.release]
+lto = true


### PR DESCRIPTION
Hi!

I noticed that in the `Cargo.toml` file Link-Time Optimization (LTO) for the project is not enabled. I suggest switching it on since it will reduce the binary size (which is always a good thing to have).

I have made quick tests (Fedora 41, Rustc 1.83) by adding `lto = true` to the Release profile. The binary size reduction is from 5 Mib to 3.9 Mib.

Thank you.